### PR TITLE
feat: add inline active-task summary bar

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-import { addTodo, deleteTodo, filterTodos, getCounts, toggleTodo } from "../src/todos.js";
+import { addTodo, deleteTodo, filterTodos, getCounts, getSummary, toggleTodo } from "../src/todos.js";
 
 const storageKey = "symphony.todo-tracker.todos";
 
@@ -7,6 +7,7 @@ const elements = {
   input: document.querySelector("#todo-input"),
   list: document.querySelector("#todo-list"),
   counts: document.querySelector("#counts"),
+  summary: document.querySelector("#summary"),
   emptyState: document.querySelector("#empty-state"),
   filters: [...document.querySelectorAll(".filter")]
 };
@@ -49,6 +50,7 @@ function render() {
   const counts = getCounts(state.todos);
 
   elements.counts.textContent = `${counts.all} total, ${counts.active} active, ${counts.completed} completed`;
+  elements.summary.textContent = getSummary(state.todos);
   elements.emptyState.hidden = filtered.length > 0;
   elements.list.innerHTML = "";
 

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,8 @@
           <button type="submit">Add Task</button>
         </form>
 
+        <div id="summary" class="summary-bar" aria-live="polite"></div>
+
         <div class="toolbar">
           <div id="counts" class="counts" aria-live="polite"></div>
           <div class="filters" role="tablist" aria-label="Todo filters">

--- a/public/styles.css
+++ b/public/styles.css
@@ -91,12 +91,19 @@ h1 {
   cursor: pointer;
 }
 
+.summary-bar {
+  margin: 20px 0 8px;
+  font-size: 1rem;
+  font-weight: bold;
+  color: var(--accent);
+}
+
 .toolbar {
   display: flex;
   justify-content: space-between;
   gap: 16px;
   align-items: center;
-  margin: 20px 0 16px;
+  margin: 0 0 16px;
   flex-wrap: wrap;
 }
 

--- a/src/todos.js
+++ b/src/todos.js
@@ -47,3 +47,10 @@ export function getCounts(todos) {
     completed
   };
 }
+
+export function getSummary(todos) {
+  const { active } = getCounts(todos);
+  if (active === 0) return "All tasks complete";
+  if (active === 1) return "1 task left";
+  return `${active} tasks left`;
+}

--- a/tests/todos.test.js
+++ b/tests/todos.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { addTodo, createTodo, deleteTodo, filterTodos, getCounts, toggleTodo } from "../src/todos.js";
+import { addTodo, createTodo, deleteTodo, filterTodos, getCounts, getSummary, toggleTodo } from "../src/todos.js";
 
 function test(name, fn) {
   try {
@@ -47,6 +47,27 @@ test("filterTodos supports active and completed", () => {
 test("getCounts returns summary totals", () => {
   const todos = [createTodo("A"), { ...createTodo("B"), completed: true }];
   assert.deepEqual(getCounts(todos), { all: 2, active: 1, completed: 1 });
+});
+
+test("getSummary returns 'All tasks complete' when no active todos", () => {
+  assert.equal(getSummary([]), "All tasks complete");
+  const allDone = [{ ...createTodo("A"), completed: true }];
+  assert.equal(getSummary(allDone), "All tasks complete");
+});
+
+test("getSummary returns '1 task left' when one active todo", () => {
+  const todos = [createTodo("A")];
+  assert.equal(getSummary(todos), "1 task left");
+});
+
+test("getSummary returns 'N tasks left' when multiple active todos", () => {
+  const todos = [createTodo("A"), createTodo("B"), createTodo("C")];
+  assert.equal(getSummary(todos), "3 tasks left");
+});
+
+test("getSummary ignores completed todos in count", () => {
+  const todos = [createTodo("A"), { ...createTodo("B"), completed: true }, createTodo("C")];
+  assert.equal(getSummary(todos), "2 tasks left");
 });
 
 console.log("All tests passed.");


### PR DESCRIPTION
## Summary
- Adds a `.summary-bar` element above the filter toolbar that shows the next actionable status for the task list
- New `getSummary(todos)` function in `src/todos.js` returns `"All tasks complete"`, `"1 task left"`, or `"N tasks left"`
- `render()` in `app.js` now calls `getSummary` and updates the element after every add, toggle, and delete action

## Test plan
- [x] `getSummary` returns `"All tasks complete"` with no todos
- [x] `getSummary` returns `"All tasks complete"` when all todos are completed
- [x] `getSummary` returns `"1 task left"` with one active todo
- [x] `getSummary` returns `"3 tasks left"` with three active todos
- [x] `getSummary` ignores completed todos in count
- [x] All 10 tests pass (`npm test`)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)